### PR TITLE
use last event time to determine current time

### DIFF
--- a/54,-56-video-player/src/tests/video-player/index.test.ts
+++ b/54,-56-video-player/src/tests/video-player/index.test.ts
@@ -36,9 +36,9 @@ async function waitTimeAndAssertSnapshot(
 ): Promise<void> {
   const startAt = Date.now()
   await new Promise<void>((resolve, reject) => {
-    var lastTickNumber = -1
-    var lastEventTime = -1
-    var lastEventOffset = -1
+    let lastTickNumber = -1
+    let lastEventTime = -1
+    let lastEventOffset = -1
 
     function snapshotSystem(): void {
       const videoState = getVideoState(screenEntity)
@@ -50,7 +50,7 @@ async function waitTimeAndAssertSnapshot(
 
       if (videoState === undefined) return
       if (videoState.timestamp === undefined) return
-      if (videoState.state != VideoState.VS_PLAYING) return
+      if (videoState.state !== VideoState.VS_PLAYING) return
 
       if (videoState.tickNumber > lastTickNumber) {
         lastTickNumber = videoState.tickNumber

--- a/54,-56-video-player/src/tests/video-player/index.test.ts
+++ b/54,-56-video-player/src/tests/video-player/index.test.ts
@@ -29,7 +29,11 @@ function getVideoState(entity: Entity): PBVideoEvent | undefined {
 
 const TIMEOUT_MS = 100_000
 
-async function waitTimeAndAssertSnapshot(screenEntity: Entity, t: number, snapshotId: number): Promise<void> {
+async function waitTimeAndAssertSnapshot(
+  screenEntity: Entity,
+  t: number,
+  snapshotId: number
+): Promise<void> {
   const startAt = Date.now()
   await new Promise<void>((resolve, reject) => {
     let lastTickNumber = -1
@@ -54,11 +58,14 @@ async function waitTimeAndAssertSnapshot(screenEntity: Entity, t: number, snapsh
         lastEventOffset = videoState.currentOffset
       }
 
-      const currentOffset = lastEventOffset + (Date.now() - lastEventTime) / 1000
+      const currentOffset =
+        lastEventOffset + (Date.now() - lastEventTime) / 1000
 
       if (currentOffset >= t && currentOffset < t + 0.5) {
         engine.removeSystem(systemId)
-        console.log(`Taking snapshot ${snapshotId} with video at ${currentOffset}`)
+        console.log(
+          `Taking snapshot ${snapshotId} with video at ${currentOffset}`
+        )
         assertSnapshot(
           `screenshot/$explorer_snapshot_video_player_${snapshotId}.png`,
           Vector3.create(8, 8, 8),

--- a/54,-56-video-player/src/tests/video-player/index.test.ts
+++ b/54,-56-video-player/src/tests/video-player/index.test.ts
@@ -6,7 +6,8 @@ import {
   engine,
   type Entity,
   VideoEvent,
-  type PBVideoEvent
+  type PBVideoEvent,
+  VideoState
 } from '@dcl/sdk/ecs'
 import { Vector3 } from '@dcl/sdk/math'
 
@@ -35,7 +36,9 @@ async function waitTimeAndAssertSnapshot(
 ): Promise<void> {
   const startAt = Date.now()
   await new Promise<void>((resolve, reject) => {
-    let timePreviousCrossed = false
+    var lastTickNumber = -1
+    var lastEventTime = -1
+    var lastEventOffset = -1
 
     function snapshotSystem(): void {
       const videoState = getVideoState(screenEntity)
@@ -47,15 +50,20 @@ async function waitTimeAndAssertSnapshot(
 
       if (videoState === undefined) return
       if (videoState.timestamp === undefined) return
+      if (videoState.state != VideoState.VS_PLAYING) return
 
-      if (videoState.currentOffset < t) {
-        timePreviousCrossed = true
+      if (videoState.tickNumber > lastTickNumber) {
+        lastTickNumber = videoState.tickNumber
+        lastEventTime = Date.now()
+        lastEventOffset = videoState.currentOffset
       }
 
-      if (timePreviousCrossed && videoState.currentOffset >= t) {
+      const currentOffset = lastEventOffset + (Date.now() - lastEventTime) / 1000
+
+      if (currentOffset >= t && currentOffset < t + 0.5) {
         engine.removeSystem(systemId)
         console.log(
-          `Taking snapshot ${snapshotId} with video at ${videoState.currentOffset}`
+          `Taking snapshot ${snapshotId} with video at ${currentOffset}`
         )
         assertSnapshot(
           `screenshot/$explorer_snapshot_video_player_${snapshotId}.png`,
@@ -103,8 +111,8 @@ test('video-player: if exist a reference snapshot should match with it', async f
     metallic: 0
   })
 
-  await waitTimeAndAssertSnapshot(screenEntity, 0.5, 1)
-  await waitTimeAndAssertSnapshot(screenEntity, 1.5, 2)
-  await waitTimeAndAssertSnapshot(screenEntity, 2.5, 3)
-  await waitTimeAndAssertSnapshot(screenEntity, 3.5, 4)
+  await waitTimeAndAssertSnapshot(screenEntity, 0.25, 1)
+  await waitTimeAndAssertSnapshot(screenEntity, 1.25, 2)
+  await waitTimeAndAssertSnapshot(screenEntity, 2.25, 3)
+  await waitTimeAndAssertSnapshot(screenEntity, 3.25, 4)
 })

--- a/54,-56-video-player/src/tests/video-player/index.test.ts
+++ b/54,-56-video-player/src/tests/video-player/index.test.ts
@@ -29,11 +29,7 @@ function getVideoState(entity: Entity): PBVideoEvent | undefined {
 
 const TIMEOUT_MS = 100_000
 
-async function waitTimeAndAssertSnapshot(
-  screenEntity: Entity,
-  t: number,
-  snapshotId: number
-): Promise<void> {
+async function waitTimeAndAssertSnapshot(screenEntity: Entity, t: number, snapshotId: number): Promise<void> {
   const startAt = Date.now()
   await new Promise<void>((resolve, reject) => {
     let lastTickNumber = -1
@@ -62,9 +58,7 @@ async function waitTimeAndAssertSnapshot(
 
       if (currentOffset >= t && currentOffset < t + 0.5) {
         engine.removeSystem(systemId)
-        console.log(
-          `Taking snapshot ${snapshotId} with video at ${currentOffset}`
-        )
+        console.log(`Taking snapshot ${snapshotId} with video at ${currentOffset}`)
         assertSnapshot(
           `screenshot/$explorer_snapshot_video_player_${snapshotId}.png`,
           Vector3.create(8, 8, 8),


### PR DESCRIPTION
video events may not be sent continuously. we can use the system elapsed time the last play event was received to estimate the current video offset.